### PR TITLE
Guard against duplicate variable declarations in Beat compiler

### DIFF
--- a/src/vm/compiler.cpp
+++ b/src/vm/compiler.cpp
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <format>
 
 #include "compiler.hpp"
 #include "token.hpp"
@@ -263,7 +264,25 @@ void Compiler::visit(const PrintStmt &stmt) {
 
 void Compiler::visit(const VarStmt &stmt) {
     if (scopeDepth > 0) {
+        for (int i = locals.size() - 1; i >= 0; --i) {
+            const auto &local = locals[i];
+            if (local.depth != -1 && local.depth < scopeDepth) {
+                break;
+            }
+            if (local.name.lexeme == stmt.name.lexeme) {
+                throw CompileException(std::format("L:{} T:IDENTIFIER V:{}: Already a variable with this name in this scope.",
+                                                 stmt.name.line,
+                                                 stmt.name.lexeme));
+            }
+        }
         locals.push_back({stmt.name, -1, false});
+    } else {
+        auto result = globalVariables.insert(stmt.name.lexeme);
+        if (!result.second) {
+            throw CompileException(std::format("L:{} T:IDENTIFIER V:{}: Already a variable with this name in this scope.",
+                                             stmt.name.line,
+                                             stmt.name.lexeme));
+        }
     }
     if (stmt.initializer) {
         stmt.initializer->accept(*this);

--- a/src/vm/compiler.hpp
+++ b/src/vm/compiler.hpp
@@ -3,6 +3,7 @@
 #include "expr.hpp"
 #include "statement.hpp"
 #include "token.hpp"
+#include <unordered_set>
 
 class CompileException: public std::runtime_error {
     public:
@@ -34,6 +35,7 @@ public:
     // except that locals store meta-info about the local variable, the VM stack storing the values only
     // because statements have net-zero effect on stack
     std::vector<Local> locals;
+    std::unordered_set<std::string> globalVariables;
 
     Compiler(Compiler* enclosing ): enclosing(enclosing) {}
 
@@ -75,6 +77,7 @@ public:
     inline void clear() {
         chunk.clear_byteclodes();
         chunk.clear_lines();
+        globalVariables.clear();
     }
 
     inline void beginScope() {


### PR DESCRIPTION
## Summary
- detect duplicate local declarations while compiling Beat bytecode
- track global declarations per compilation unit so repeated globals fail to compile
- reset tracked globals when clearing the compiler state

## Testing
- `cmake -S . -B build`
- `cmake --build build --target beat`


------
https://chatgpt.com/codex/tasks/task_e_68ddecc2f1548324ad7550655a82f212